### PR TITLE
Fixxing issue with multiple instances of the banner component

### DIFF
--- a/components/Banners.php
+++ b/components/Banners.php
@@ -34,7 +34,7 @@ class Banners extends \System\Classes\BaseComponent
         return BannerModel::isEnabled()->dropdown('name');
     }
 
-    public function onRun()
+    public function onRender()
     {
         $this->page['banner'] = $this->loadBanner();
     }


### PR DESCRIPTION
when multiple instances of the banner component are loaded on the same page, the last declared in FrontMatter overwrites the other ones, causing same banner ID to be shown multiply times instead of different ones. Described here https://forum.tastyigniter.com/d/1849-problem-with-banners post #1