### PR TITLE
Release v4.0.9

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -25,7 +25,7 @@ class Extension extends BaseExtension
     {
         $this->registerReCaptcha();
 
-        $this->app->singleton(MailChimp::class, fn(): MailChimp => new MailChimp(MailChimpSettings::getApiKey()));
+        $this->app->singleton(MailChimp::class, fn(): MailChimp => new MailChimp(MailchimpSettings::getApiKey()));
     }
 
     #[Override]


### PR DESCRIPTION
This release contains a minor bug fix to correct a naming inconsistency in the Mailchimp integration.

## Fixed

- Corrected a typo in the settings class reference, renaming `MailChimpSettings` to `MailchimpSettings` in `Extension.php`